### PR TITLE
Add dc_output and dc_power_out properties to C1000 (Gen 1)

### DIFF
--- a/SolixBLE/devices/c1000.py
+++ b/SolixBLE/devices/c1000.py
@@ -187,6 +187,25 @@ class C1000(SolixBLEDevice):
         return self._parse_int("b0", begin=1)
 
     @property
+    def dc_output(self) -> PortStatus:
+        """DC Port Status.
+
+        PortStatus.NOT_CONNECTED signifies off.
+        PortStatus.OUTPUT signifies on.
+
+        :returns: Status of the DC output port.
+        """
+        return PortStatus(self._parse_int("b2", begin=1, end=2))
+
+    @property
+    def dc_power_out(self) -> int:
+        """DC Power Out.
+
+        :returns: DC power out or default int value.
+        """
+        return self._parse_int("b2", begin=2)
+
+    @property
     def software_version(self) -> str:
         """Main software version.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,9 +50,9 @@ AC on/off state         ✅        N/A         ✅        ✅        ✅        
 AC Timer                ✅        N/A         ✅        ✅        ❌         ❌           ❌  
 DC on/off control       ✅        ❌          ✅        ✅        ✅         ❌           ❌
 DC Power in             ✅        ✅          ✅        ✅        ✅         ✅           ✅   
-DC Power out            ✅        ✅          ❌        ❌        ✅         ✅           ✅  
+DC Power out            ✅        ✅          ❌        ✅        ✅         ✅           ✅  
 DC Power in status      ✅        ✅          ❌        ❌        ✅         ❌           ❌ 
-DC Power out status     ✅        ❌          ❌        ❌        ✅         ❌           ✅   
+DC Power out status     ✅        ❌          ❌        ✅        ✅         ❌           ✅   
 DC Timer                ✅        ✅          ❌        ❌        ❌         ❌           ❌ 
 USB Power out           ✅        ✅          ✅        ✅        ✅         ✅           ✅     
 USB Port status         ✅        ✅          ❌        ❌        ✅         ❌           ✅ 


### PR DESCRIPTION
### What's missing

The `C1000` class has `turn_dc_on()` / `turn_dc_off()` but no `dc_output` status property, making it impossible to read back DC output state without calling the private `_parse_int("b2", ...)` directly.

`C1000G2` already defines `dc_output` and `dc_power_out` from the `b2` telemetry parameter. This PR adds the same two properties to the Gen 1 class.

### Empirical confirmation

Tested on a real C1000 Gen 1 (A1761, firmware 1.6.6).

With DC output physically **on**, raw telemetry `b2` was `020100`:

- byte 1 = `01` → `PortStatus.OUTPUT` ✓

`dc_power_out` (byte 2+) read `0` in this sample — the output was enabled but at standby with no load, so the value is plausible but not confirmed under active draw. Byte offsets mirror the Gen 2 mapping exactly.

### Note on Gen 2

`C1000G2` has `dc_output`/`dc_power_out` but is missing `turn_dc_on/off`. Those control methods exist in Gen 1 (`CMD_DC_OUTPUT = "404b"`). I don't have Gen 2 hardware to test, but flagging it in case someone else can confirm.