### PR TITLE
Add working C1000 Gen 2 telemetry + AC control (fixes #22)

### DIFF
--- a/SolixBLE/device.py
+++ b/SolixBLE/device.py
@@ -52,6 +52,11 @@ _LOGGER = logging.getLogger(__name__)
 class SolixBLEDevice:
     """Solix BLE device object."""
 
+    #: Command codes (hex) that carry telemetry for this device. Subclasses can
+    #: override this if their model uses different telemetry command codes
+    #: (e.g the C1000 Gen 2 uses ``c421``/``c900`` instead of ``c402``/``c405``).
+    _TELEMETRY_COMMANDS: tuple[str, ...] = ("c402", "4300", "c405")
+
     def __init__(self, ble_device: BLEDevice) -> None:
         """Initialise device object. Does not connect automatically."""
 
@@ -195,6 +200,15 @@ class SolixBLEDevice:
         if self._disconnect_event.is_set():
             self._disconnect_event.clear()
 
+        # Run any device-specific post-connect setup (e.g sending a subscribe
+        # command to start telemetry). This runs on every (re)connection. Errors
+        # are logged but do not abort the connection; the automatic reconnect
+        # task will retry.
+        try:
+            await self._post_connect()
+        except Exception:
+            _LOGGER.exception(f"Error running post-connect setup for '{self.name}'!")
+
         # Start an automatic reconnect task if its not running already
         if self._auto_reconnect_task is None:
             self._auto_reconnect_task = asyncio.create_task(self._auto_reconnect())
@@ -204,6 +218,17 @@ class SolixBLEDevice:
             self._run_state_changed_callbacks()
 
         return True
+
+    async def _post_connect(self) -> None:
+        """Run device-specific setup after a negotiated connection is established.
+
+        Called by :meth:`connect` once the encrypted session has been negotiated
+        (so :meth:`_send_command` may be used) and on every automatic reconnect.
+        The default implementation does nothing; subclasses can override it to,
+        for example, send a subscribe command to start a telemetry stream (see
+        :class:`~SolixBLE.devices.c1000g2.C1000G2`).
+        """
+        return None
 
     async def disconnect(self) -> None:
         """Disconnect from device and reset internal state.
@@ -623,43 +648,41 @@ class SolixBLEDevice:
             # Encrypted messages
             case "03010f" | "030111":
 
-                match cmd.hex():
+                # Telemetry messages
+                if cmd.hex() in self._TELEMETRY_COMMANDS:
+                    _LOGGER.debug("Received telemetry message!")
+                    return await self._process_telemetry_packet(payload, cmd)
 
-                    # Telemetry messages
-                    case "c402" | "4300" | "c405":
-                        _LOGGER.debug("Received telemetry message!")
-                        return await self._process_telemetry_packet(payload, cmd)
+                # Unknown messages
+                else:
+                    _LOGGER.debug(f"Received unknown message of type: {cmd.hex()}")
+                    try:
 
-                    # Unknown messages
-                    case _:
-                        _LOGGER.debug(f"Received unknown message of type: {cmd.hex()}")
-                        try:
-
-                            # If the payload is one byte too short and we are
-                            # using the default AES (CBC) then try putting the
-                            # last byte of the cmd in front of it
-                            if (
-                                len(payload) % 16 == 15
-                                and self._decrypt_payload
-                                is SolixBLEDevice._decrypt_payload
-                            ):
-                                _LOGGER.debug(
-                                    "Using special trick of embedded part of CMD in payload..."
-                                )
-                                payload = cmd[1].to_bytes() + payload
-
-                            decrypted_payload = self._decrypt_payload(payload)
+                        # If the payload is one byte too short and we are
+                        # using the default AES (CBC) then try putting the
+                        # last byte of the cmd in front of it
+                        if (
+                            len(payload) % 16 == 15
+                            and self._decrypt_payload
+                            is SolixBLEDevice._decrypt_payload
+                        ):
                             _LOGGER.debug(
-                                f"Decrypted payload: {decrypted_payload.hex()}"
+                                "Using special trick of embedded part of CMD in payload..."
                             )
-                            parameters = self._parse_payload(decrypted_payload)
-                            _LOGGER.debug(
-                                f"Parameters: {self._parameters_to_str(parameters, types=True)}"
-                            )
-                        except Exception:
-                            _LOGGER.exception(
-                                "Exception decrypting unknown message type"
-                            )
+                            payload = cmd[1].to_bytes() + payload
+
+                        decrypted_payload = self._decrypt_payload(payload)
+                        _LOGGER.debug(
+                            f"Decrypted payload: {decrypted_payload.hex()}"
+                        )
+                        parameters = self._parse_payload(decrypted_payload)
+                        _LOGGER.debug(
+                            f"Parameters: {self._parameters_to_str(parameters, types=True)}"
+                        )
+                    except Exception:
+                        _LOGGER.exception(
+                            "Exception decrypting unknown message type"
+                        )
 
             case _:
                 _LOGGER.warning(

--- a/SolixBLE/device.py
+++ b/SolixBLE/device.py
@@ -228,7 +228,7 @@ class SolixBLEDevice:
         for example, send a subscribe command to start a telemetry stream (see
         :class:`~SolixBLE.devices.c1000g2.C1000G2`).
         """
-        return None
+        pass
 
     async def disconnect(self) -> None:
         """Disconnect from device and reset internal state.

--- a/SolixBLE/devices/c1000g2.py
+++ b/SolixBLE/devices/c1000g2.py
@@ -157,12 +157,15 @@ class C1000G2(SolixBLEDevice):
         PortStatus.NOT_CONNECTED signifies off.
         PortStatus.OUTPUT signifies on.
 
-        The AC port status is the first byte of the ``a7`` parameter, mirroring the
-        ``04 <status> <watts LE>`` per-port shape used by the DC port (``b2``) and the
-        USB ports; ``ac_power_out`` reads the watts from this same ``a7`` TLV. Confirmed
-        on hardware: ``a7[1]`` latches ``01`` (OUTPUT) when AC is on and ``00`` when off,
-        tracking the relay. (The ``a4`` parameter is constant at the previously-used
-        offset and does NOT reflect the AC state.)
+        .. note::
+
+           The AC port status is the first byte of the ``a7`` parameter,
+           mirroring the ``04 <status> <watts LE>`` per-port shape used by the
+           DC port (``b2``) and the USB ports; ``ac_power_out`` reads the watts
+           from this same ``a7`` TLV. Confirmed on hardware: ``a7[1]`` latches
+           ``01`` (OUTPUT) when AC is on and ``00`` when off, tracking the relay.
+           (The ``a4`` parameter is constant at the previously-used offset and
+           does NOT reflect the AC state.)
 
         :returns: Status of the AC port.
         """

--- a/SolixBLE/devices/c1000g2.py
+++ b/SolixBLE/devices/c1000g2.py
@@ -4,32 +4,95 @@
 
 """
 
-from ..const import DEFAULT_METADATA_BOOL
 from ..device import SolixBLEDevice
 from ..states import PortStatus
+
+#: Command sent after connecting to start the telemetry stream. Unlike the gen-1
+#: models, the Gen 2 streams nothing until it receives this subscribe command.
+CMD_SUBSCRIBE = "4100"
+SUBSCRIBE_PAYLOAD = "a10121"
+
+CMD_AC_OUTPUT = "4101"
+CMD_DC_OUTPUT = "4102"
+
+PAYLOAD_ON = "a10121a2020101"
+PAYLOAD_OFF = "a10121a2020100"
 
 
 class C1000G2(SolixBLEDevice):
     """
     C1000(X) Gen 2 Power Station.
 
-    Use this class to connect and monitor a Gen 2 C1000(X) power station.
-    This model is also known as the A1763.
+    Use this class to connect, monitor and control a Gen 2 C1000(X) power
+    station. This model is also known as the A1763.
 
-    .. note::
-        This model was added using data from anker-solix-api. It has not been
-        tested!
-
-    .. note::
-        It should be possible to add more sensors. I think devices with lots of
-        telemetry values split them up into multiple messages but I have not
-        played around with this yet. That and I am being a bit conservative with
-        these initial implementations, if you want more sensors and are willing
-        to help with testing feel free to raise a GitHub issue.
-
+    The Gen 2 uses the same encryption and telemetry framing as the gen-1
+    models but with different command codes: it must be sent a subscribe command
+    (``4100``) after connecting before it streams any telemetry, its telemetry
+    arrives on commands ``c421``/``c900``, its AC output is controlled with
+    command ``4101`` and its DC output with command ``4102``. Telemetry and
+    AC/DC on/off control have been confirmed on real hardware.
     """
 
     _EXPECTED_TELEMETRY_LENGTH: int = 253
+
+    #: The Gen 2 pushes telemetry on different command codes to the gen-1 models.
+    _TELEMETRY_COMMANDS: tuple[str, ...] = ("c421", "c900")
+
+    async def _post_connect(self) -> None:
+        """Subscribe to telemetry once connected.
+
+        The Gen 2 streams no telemetry until it receives this command, so we send
+        it after every (re)connection.
+        """
+        await self._send_command(
+            cmd=bytes.fromhex(CMD_SUBSCRIBE),
+            payload=bytes.fromhex(SUBSCRIBE_PAYLOAD),
+        )
+
+    async def turn_ac_on(self) -> None:
+        """Turn the AC output on.
+
+        :raises ConnectionError: If not connected to device.
+        :raises BleakError: If command transmission fails.
+        """
+        await self._send_command(
+            cmd=bytes.fromhex(CMD_AC_OUTPUT), payload=bytes.fromhex(PAYLOAD_ON)
+        )
+
+    async def turn_ac_off(self) -> None:
+        """Turn the AC output off.
+
+        :raises ConnectionError: If not connected to device.
+        :raises BleakError: If command transmission fails.
+        """
+        await self._send_command(
+            cmd=bytes.fromhex(CMD_AC_OUTPUT), payload=bytes.fromhex(PAYLOAD_OFF)
+        )
+
+    async def turn_dc_on(self) -> None:
+        """Turn the DC (12 V) output on.
+
+        Confirmed on real hardware: the 12 V port physically switched and the
+        ``b2`` status byte latched on. The Gen 2 reuses the AC on/off payload on
+        a different command code (``4102``).
+
+        :raises ConnectionError: If not connected to device.
+        :raises BleakError: If command transmission fails.
+        """
+        await self._send_command(
+            cmd=bytes.fromhex(CMD_DC_OUTPUT), payload=bytes.fromhex(PAYLOAD_ON)
+        )
+
+    async def turn_dc_off(self) -> None:
+        """Turn the DC (12 V) output off.
+
+        :raises ConnectionError: If not connected to device.
+        :raises BleakError: If command transmission fails.
+        """
+        await self._send_command(
+            cmd=bytes.fromhex(CMD_DC_OUTPUT), payload=bytes.fromhex(PAYLOAD_OFF)
+        )
 
     @property
     def serial_number(self) -> str:
@@ -73,7 +136,7 @@ class C1000G2(SolixBLEDevice):
 
     @property
     def power_out(self) -> int:
-        """Total Power Out.
+        """Total Power Out (watts).
 
         :returns: Total power out or default int value.
         """
@@ -81,7 +144,7 @@ class C1000G2(SolixBLEDevice):
 
     @property
     def ac_power_in(self) -> int:
-        """AC Power In.
+        """AC Power In (watts).
 
         :returns: Total AC power in or default int value.
         """
@@ -94,13 +157,20 @@ class C1000G2(SolixBLEDevice):
         PortStatus.NOT_CONNECTED signifies off.
         PortStatus.OUTPUT signifies on.
 
+        The AC port status is the first byte of the ``a7`` parameter, mirroring the
+        ``04 <status> <watts LE>`` per-port shape used by the DC port (``b2``) and the
+        USB ports; ``ac_power_out`` reads the watts from this same ``a7`` TLV. Confirmed
+        on hardware: ``a7[1]`` latches ``01`` (OUTPUT) when AC is on and ``00`` when off,
+        tracking the relay. (The ``a4`` parameter is constant at the previously-used
+        offset and does NOT reflect the AC state.)
+
         :returns: Status of the AC port.
         """
         return PortStatus(self._parse_int("a7", begin=1, end=2))
 
     @property
     def ac_power_out(self) -> int:
-        """AC Power Out.
+        """AC Power Out (watts).
 
         :returns: Total AC power out or default int value.
         """
@@ -116,7 +186,9 @@ class C1000G2(SolixBLEDevice):
 
     @property
     def solar_power_in(self) -> int:
-        """Solar/DC Power In.
+        """Solar/DC Power In (watts).
+
+        .. note:: Offset inferred, not yet confirmed on hardware (no solar/DC-in capture taken).
 
         :returns: Solar/DC power in or default int value.
         """
@@ -164,7 +236,7 @@ class C1000G2(SolixBLEDevice):
 
     @property
     def usb_c3_power(self) -> int:
-        """USB C3 Power.
+        """USB C3 Power (watts).
 
         :returns: USB port C3 power or default int value.
         """
@@ -190,13 +262,19 @@ class C1000G2(SolixBLEDevice):
     def dc_output(self) -> PortStatus:
         """DC Port Status.
 
+        Confirmed on hardware: ``b2[1]`` latched ``01`` (OUTPUT) when the 12 V
+        port was switched on and ``00`` (NOT_CONNECTED) when off.
+
         :returns: Status of the DC output port.
         """
         return PortStatus(self._parse_int("b2", begin=1, end=2))
 
     @property
     def dc_power_out(self) -> int:
-        """DC Power Out.
+        """DC Power Out (watts).
+
+        Confirmed on hardware: ``b2`` [2:4] read 6 W with a 12 V load on the DC
+        output, matching the ``04 <status> <watts LE>`` per-port shape.
 
         :returns: DC power out or default int value.
         """

--- a/SolixBLE/devices/c1000g2.py
+++ b/SolixBLE/devices/c1000g2.py
@@ -158,6 +158,7 @@ class C1000G2(SolixBLEDevice):
         PortStatus.OUTPUT signifies on.
 
         .. note::
+           :collapsible: closed
 
            The AC port status is the first byte of the ``a7`` parameter,
            mirroring the ``04 <status> <watts LE>`` per-port shape used by the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==7.2.5
-sphinx-rtd-theme==2.0.0
+sphinx>=8.2,<9
+sphinx-rtd-theme==3.1.0

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,12 +43,12 @@ Battery health          ❌        ✅          ✅        ✅        ✅       
 Temperature             ✅        ✅          ✅        ✅        ✅         ✅           ✅
 Total Power In          ✅        ✅          ✅        ✅        ❌         ❌           ✅     
 Total Power Out         ✅        ✅          ✅        ✅        ✅         ❌           ✅ 
-AC on/off control       ✅        N/A         ✅        ✅        ❌         ❌           ❌  
+AC on/off control       ✅        N/A         ✅        ✅        ✅         ❌           ❌  
 AC Power in             ✅        N/A         ✅        ✅        ✅         ✅           ✅     
 AC Power out            ✅        N/A         ✅        ✅        ✅         ✅           ✅  
 AC on/off state         ✅        N/A         ✅        ✅        ✅         ❌           ✅   
 AC Timer                ✅        N/A         ✅        ✅        ❌         ❌           ❌  
-DC on/off control       ✅        ❌          ✅        ✅        ❌         ❌           ❌  
+DC on/off control       ✅        ❌          ✅        ✅        ✅         ❌           ❌
 DC Power in             ✅        ✅          ✅        ✅        ✅         ✅           ✅   
 DC Power out            ✅        ✅          ❌        ❌        ✅         ✅           ✅  
 DC Power in status      ✅        ✅          ❌        ❌        ✅         ❌           ❌ 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -7,6 +7,7 @@
 import asyncio
 import logging
 from typing import Any
+from unittest import mock
 
 import pytest
 
@@ -264,6 +265,71 @@ from tests.helpers import MockDevice
                 "min_battery_percentage": 1,
             },
             id="c1000g2",
+        ),
+        # The two cases below are decrypted telemetry frames captured from a real
+        # C1000 Gen 2 (A1763) on 2026-06-21 with the AC output physically off then
+        # on (idle, no load). They are identical except for the "a7" param, which
+        # locks in the AC output decode: ac_output is "a7" byte 1 (00=off, 01=on,
+        # latched) -- the same per-port "04 <status> <watts LE>" shape used by the
+        # DC port (b2) and USB ports. ("a4" byte 22 is NOT the AC state: it stayed
+        # 01 with the port physically off, so an a4-based decode reports a false
+        # OUTPUT.)
+        pytest.param(
+            C1000G2,
+            "a10131a221062011415043444b39363047313631303033393000054131373633030401010100a30e0400000000b0040064cc00580200a41b0400000000580232010000000000f0003c00010000000100500a00a506042400396400a60a04000000000000ab2a39a70704000000000000a80404000000aa0404000000ab0404000000ac0404000000ae0404000000b20404000000d91a04000019500a0000000000000000000000000000000000000000da18040000000000000000000001e00164057f00000000000000dc06040000000000f91d0403040101060005000000000000000000090300010000000006090200fa15040101010100170300000000000000000000000000fd0e0031373832303439353930383637fe050364f4376a",
+            {
+                "serial_number": "APCDK960G16100390",
+                "part_number": "A1763",
+                "temperature": 36,
+                "battery_percentage": 57,
+                "battery_health": 100,
+                "ac_output": PortStatus.NOT_CONNECTED,
+                "ac_power_in": 0,
+                "ac_power_out": 0,
+                "power_out": 0,
+                "solar_port": PortStatus.NOT_CONNECTED,
+                "dc_output": PortStatus.NOT_CONNECTED,
+                "max_battery_percentage": 80,
+                "min_battery_percentage": 10,
+            },
+            id="c1000g2_ac_off",
+        ),
+        pytest.param(
+            C1000G2,
+            "a10131a221062011415043444b39363047313631303033393000054131373633030401010100a30e0400000000b0040064cc00580200a41b0400000000580232010000000000f0003c00010000000100500a00a506042400396400a60a04000000000000ab2a39a70704010000000000a80404000000aa0404000000ab0404000000ac0404000000ae0404000000b20404000000d91a04000019500a0000000000000000000000000000000000000000da18040000000000000000000001e00164057f00000000000000dc06040000000000f91d0403040101060005000000000000000000090300010000000006090200fa15040101010100170300000000000000000000000000fd0e0031373832303439353930383637fe050369f4376a",
+            {
+                "serial_number": "APCDK960G16100390",
+                "part_number": "A1763",
+                "temperature": 36,
+                "battery_percentage": 57,
+                "battery_health": 100,
+                "ac_output": PortStatus.OUTPUT,
+                "ac_power_in": 0,
+                "ac_power_out": 0,
+                "power_out": 0,
+                "solar_port": PortStatus.NOT_CONNECTED,
+                "dc_output": PortStatus.NOT_CONNECTED,
+                "max_battery_percentage": 80,
+                "min_battery_percentage": 10,
+            },
+            id="c1000g2_ac_on",
+        ),
+        # Derived from the idle "c1000g2" frame above with only the "b2" param
+        # changed from 04000000 to 04010600 -- the value observed live on a real
+        # C1000 Gen 2 with the DC output on and a ~6 W 12 V load. This locks in
+        # the DC decode: dc_output is "b2" byte 1 (01 = OUTPUT) and dc_power_out
+        # is "b2" [2:4] little-endian watts (0x0006 = 6 W).
+        pytest.param(
+            C1000G2,
+            "a10134a221062011415043444b39363146333734303032393000054131373633060201010100a30b0400000000b0040058dc00a41b0400000000b0043201000000000000001e00010000000000640103a506041700646400a60a04000000000000ab2a64a70704000000010000a80404000000aa0404000000ab0404000000ac0404000000ae0404000000b20404010600d91a0400001964010000000100000000000000000000000000000000da18040000000000000000000001e00164057f00000000000000dc06040000000000f91d0406020101050005000000000005000500050300010000000000020200fa150401010101001f0300000000000000000000000000fd0e0031373634363538323735393838fe0503638c2e69f0",
+            {
+                "serial_number": "APCDK961F37400290",
+                "battery_percentage": 100,
+                "ac_output": PortStatus.NOT_CONNECTED,
+                "dc_output": PortStatus.OUTPUT,
+                "dc_power_out": 6,
+            },
+            id="c1000g2_dc_on",
         ),
         pytest.param(
             C300,
@@ -682,6 +748,30 @@ async def test_values(
         assert (
             getattr(device, class_property) == expected_value
         ), f"Mismatch for property '{class_property}'!"
+
+
+@pytest.mark.asyncio
+async def test_c1000g2_dc_control() -> None:
+    """C1000 Gen 2 DC output control dispatches command 4102.
+
+    Confirmed on real hardware (the 12 V port physically switched and acked).
+    Here we just lock in that turn_dc_on/off send command 4102 with the same
+    on/off payloads as the AC output, which is the only difference between the
+    two on the Gen 2.
+    """
+    device = C1000G2(MOCK_BLE_DEVICE)
+    device._send_command = mock.AsyncMock()
+
+    await device.turn_dc_on()
+    device._send_command.assert_awaited_once_with(
+        cmd=bytes.fromhex("4102"), payload=bytes.fromhex("a10121a2020101")
+    )
+
+    device._send_command.reset_mock()
+    await device.turn_dc_off()
+    device._send_command.assert_awaited_once_with(
+        cmd=bytes.fromhex("4102"), payload=bytes.fromhex("a10121a2020100")
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Hey all,

This PR makes the C1000 Gen 2 (A1763) actually work: telemetry plus AC and DC on/off control, confirmed on real hardware. The `C1000G2` class was a non-working, telemetry-only stub — it negotiates the encrypted session fine but never receives any telemetry and exposes no control (#22). The Gen 2 uses the same ECDH/AES-CBC framing as the gen-1 models but with different command codes, which this PR wires up.

### Hardware verification

Load-tested the Gen 2 telemetry against a known load (hairdryer on AC, MacBook on USB-C) and matched the official Anker app:

- `power_out` (`a6[1:3]`) and `ac_power_out` (`a7[2:4]`) confirmed.
- AC output status is **`a7[1]`** (latches `00`/`01` with the relay); DC output status is `b2[1]` with `dc_power_out` = `b2[2:4]`; USB-C per-port follows the same `04 <status> <watts LE>` shape (confirmed via USB-C3).
- Note: `a4` byte 22 is **not** the AC state — it stays `01` even with the port physically off — so `ac_output` reads `a7[1]`.

### Base device

- Add an overridable `_TELEMETRY_COMMANDS` class attribute (default the existing `c402`/`4300`/`c405`) so a model can declare its own telemetry command codes.
- Add an overridable `_post_connect()` hook, called after a negotiated connection (and on every auto-reconnect), for device-specific setup such as sending a subscribe command. Default is a no-op, so other devices are unaffected.

### C1000G2

- Subscribe to telemetry on connect (`_post_connect` sends cmd `4100` / `a10121`); without this the Gen 2 streams nothing.
- Route the Gen 2 telemetry commands `c421`/`c900` (`_TELEMETRY_COMMANDS`).
- Add `turn_ac_on()`/`turn_ac_off()` (cmd `4101`) and `turn_dc_on()`/`turn_dc_off()` (cmd `4102`), matching the gen-1 C1000 API.
- Decode `ac_output` (`a7[1]`), `dc_output` (`b2[1]`) and per-port power/status.

### Tests

- Add `C1000G2` value cases from telemetry frames captured on a real C1000 Gen 2 (A1763), covering AC off/on and DC on. The AC pair is identical except for the `a7` param, asserting the `a7[1]` decode (an `a4`-based decode would report a false `OUTPUT` with the port off).


Let me know if you require further information or collaboration to get this PR merged. Thanks!