### PR TITLE
Use default service cache value

### DIFF
--- a/SolixBLE/device.py
+++ b/SolixBLE/device.py
@@ -132,7 +132,6 @@ class SolixBLEDevice:
                 device=self._ble_device,
                 name=self.address,
                 max_attempts=max_attempts,
-                use_services_cache=False,
                 disconnected_callback=self._disconnect_callback,
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "SolixBLE"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
   "bleak>=0.19.0",
   "cryptography",


### PR DESCRIPTION
When creating a bleak client to connect to a device the use_service_cache value was set to false, overriding the default. This was done a while back when trying to diagnose an issue with missing services when connecting to a device, this PR reverts that change so the default value of true is used.

This may or may not solve the issue found [here](https://github.com/flip-dots/HaSolixBLE/issues/3#issuecomment-4880601952).